### PR TITLE
Fix: Prevents memory leak caused by input parameters in cpp client.

### DIFF
--- a/example_scenarios/clients/cpp_client/cpp_client.cpp
+++ b/example_scenarios/clients/cpp_client/cpp_client.cpp
@@ -181,6 +181,22 @@ int collectInputParams(vector<HMInputParamBase *> &InParams) {
   return numParams;
 }
 
+// Free memory of input parameters
+void deleteInputParams(vector<HMInputParamBase *> &InParams) {
+  for (auto p : InParams) {
+    switch(p->getDType()) {
+      case Int:
+        delete static_cast<HMInputParam<int>*>(p);
+        break;
+      case Float:
+        delete static_cast<HMInputParam<float>*>(p);
+        break;
+      default:
+        fatalError("Trying to free unhandled data type.");
+    }
+  }
+}
+
 // Function for mapping input parameter based on key
 auto findHMParamByKey(vector<HMInputParamBase *> &InParams, string Key) {
   for (auto it = InParams.begin(); it != InParams.end(); ++it) {
@@ -336,6 +352,7 @@ int main(int argc, char **argv) {
     i++;
   }
 
+  deleteInputParams(InParams);
   close(hypermapper.from_child);
   close(hypermapper.to_child);
 


### PR DESCRIPTION
This fixes a memory leak caused by the input parameters.

While this solves the immediate issue, in the long run it would be better to adapt the reference implementation to use smart pointers. The Makefile suggests to compile it with c++17, so all the necessary tools are available.