### PR TITLE
Fix: Enables and fixes warnings in cpp client.

### DIFF
--- a/example_scenarios/clients/cpp_client/Makefile
+++ b/example_scenarios/clients/cpp_client/Makefile
@@ -1,5 +1,5 @@
 CXX=g++
-CFLAGS=-std=c++17 -g
+CFLAGS=-std=c++17 -g -Wall
 LDFLGS=
 
 LIBS=-lstdc++fs

--- a/example_scenarios/clients/cpp_client/cpp_client.cpp
+++ b/example_scenarios/clients/cpp_client/cpp_client.cpp
@@ -267,9 +267,13 @@ int main(int argc, char **argv) {
   // Loop that communicates with HyperMapper
   // Everything is done through function calls,
   // there should be no need to modify bellow this line.
+  char* fgets_res;
   int i = 0;
   while (true) {
-    fgets(buffer, max_buffer, instream);
+    fgets_res = fgets(buffer, max_buffer, instream);
+    if (fgets_res == NULL) {
+      fatalError("'fgets' reported an error.");
+    }
     cout << "Iteration: " << i << endl;
     cout << "Recieved: " << buffer;
     // Receiving Num Requests
@@ -281,7 +285,10 @@ int main(int argc, char **argv) {
     string NumReqStr = bufferStr.substr(bufferStr.find(' ') + 1);
     int numRequests = stoi(NumReqStr);
     // Receiving input param names
-    fgets(buffer, max_buffer, instream);
+    fgets_res = fgets(buffer, max_buffer, instream);
+    if (fgets_res == NULL) {
+      fatalError("'fgets' reported an error.");
+    }
     bufferStr = string(buffer);
     cout << "Recieved: " << buffer;
     size_t pos = 0;
@@ -310,7 +317,10 @@ int main(int argc, char **argv) {
     // For each request
     for (int request = 0; request < numRequests; request++) {
       // Receiving paramter values
-      fgets(buffer, max_buffer, instream);
+      fgets_res = fgets(buffer, max_buffer, instream);
+      if (fgets_res == NULL) {
+        fatalError("'fgets' reported an error.");
+      }
       cout << "Received: " << buffer;
       bufferStr = string(buffer);
       pos = 0;

--- a/example_scenarios/clients/cpp_client/cpp_client.h
+++ b/example_scenarios/clients/cpp_client/cpp_client.h
@@ -61,8 +61,8 @@ private:
 public:
   HMInputParamBase(std::string _Name = "", ParamType _Type = ParamType::Integer,
                    DataType _DType = DataType::Int)
-      : Name(_Name), Type(_Type), DType(_DType),
-        Key("x" + std::to_string(count++)) {}
+      : Name(_Name), Key("x" + std::to_string(count++)), Type(_Type),
+        DType(_DType) {}
 
   std::string getName() const { return Name; }
   void setName(std::string _Name) { Name = _Name; }


### PR DESCRIPTION
It is up to you if you would like to have warnings enabled. I'd argue that it usually helps developers to produce better code.
I usually do have them enabled, so I stumbled upon this warning.

In my actual project, I get additional warnings for `fgets`, e.g  line 272 of the cpp file:
```cpp
fgets(buffer, max_buffer, instream);
```
saying
```
warning: ignoring return value of ‘char* fgets(char*, int, FILE*)’, declared with attribute warn_unused_result [-Wunused-result]
```
In my code I changed them to
```cpp
char* res;
res = fgets(buffer, max_buffer, instream);
if (res == NULL) {
    fatalError("'fgets' reported an error.");
}
```
Let me know if you find this a good solution for this repository and I can add it to the PR.


In any case, thanks for the reference implementation of a C++ cilent. It helped me a lot to use hypermapper with my application.