### PR TITLE
Write to csv as soon as the black-box is evaluated.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="hypermapper",
-    version="2.2.2",
+    version="2.2.3",
     description="HyperMapper is a multi-objective black-box optimization tool based on Bayesian Optimization.",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Changed the way HyperMapper writes results to the output csv file. Now the function that runs the black-box function also writes the results. This makes HM write the DoE results as soon as they are evaluated, instead of only after all DoE configurations were evaluated. Now users will no longer loose progress if HM crashes during DoE.

The code is now also cleaner. Previously the same code snippet to write results to csv was replicated in several places, for all optimization methods. That is no longer needed.