### PR TITLE
Add flag for verbose logging

### DIFF
--- a/hypermapper/bo.py
+++ b/hypermapper/bo.py
@@ -89,6 +89,7 @@ def main(config, black_box_function=None, profiling=None):
     # Start logging
     log_file = deal_with_relative_and_absolute_path(run_directory, config["log_file"])
     sys.stdout.change_log_file(log_file)
+    sys.stdout.set_verbose_mode(config["verbose_logging"])
     if hypermapper_mode == "client-server":
         sys.stdout.switch_log_only_on_file(True)
 

--- a/hypermapper/evolution.py
+++ b/hypermapper/evolution.py
@@ -426,6 +426,7 @@ def main(config, black_box_function=None, output_file="", profiling=None):
 
     log_file = deal_with_relative_and_absolute_path(run_directory, config["log_file"])
     sys.stdout.change_log_file(log_file)
+    sys.stdout.set_verbose_mode(config["verbose_logging"])
     if hypermapper_mode == "client-server":
         sys.stdout.switch_log_only_on_file(True)
 

--- a/hypermapper/local_search.py
+++ b/hypermapper/local_search.py
@@ -747,7 +747,7 @@ def local_search(
     result_array = {}
     for i in range(number_of_configurations):
         result = output_queue.get()
-        sys.stdout.write_to_logfile(result["logstring"])
+        sys.stdout.write_to_logfile(result["logstring"], msg_is_verbose=True)
         result_array = concatenate_data_dictionaries(result_array, result["data_array"])
     data_array = concatenate_data_dictionaries(result_array, data_array)
 
@@ -899,6 +899,7 @@ def main(config, black_box_function=None, profiling=None):
 
     log_file = deal_with_relative_and_absolute_path(run_directory, config["log_file"])
     sys.stdout.change_log_file(log_file)
+    sys.stdout.set_verbose_mode(config["verbose_logging"])
     if hypermapper_mode == "client-server":
         sys.stdout.switch_log_only_on_file(True)
 

--- a/hypermapper/schema.json
+++ b/hypermapper/schema.json
@@ -13,6 +13,11 @@
         "type": "string",
         "default": "hypermapper_logfile.log"
       },
+      "verbose_logging": {
+          "description": "Enables verbose logging. Verbose logging makes the logfile significantly larger, but includes information that is helpful for debugging.",
+          "type": "boolean",
+          "default": false
+      },
       "profiling": {
         "description": "Run a profiling run of hypermapper, displaying the time allocation between different parts of the application.",
         "type": "boolean",

--- a/hypermapper/utility_functions.py
+++ b/hypermapper/utility_functions.py
@@ -129,6 +129,7 @@ class Logger:
             print("Unexpected error opening the log file: ", self.filename)
             raise
         self.log_only_on_file = False
+        self.is_verbose = False
 
     def write(self, message):
         if not self.log_only_on_file:
@@ -162,8 +163,12 @@ class Logger:
                 print("Unexpected error opening the log file: ", self.filename)
                 raise
 
-    def write_to_logfile(self, message):
-        self.log.write(message)
+    def set_verbose_mode(self, is_verbose):
+        self.is_verbose = is_verbose
+
+    def write_to_logfile(self, message, msg_is_verbose=False):
+        if not msg_is_verbose or self.is_verbose:
+            self.log.write(message)
 
     def close_log_file(self):
         self.log.close()


### PR DESCRIPTION
This change adds a flag verbose_logging
which enables some logfile prints that are disabled by default.
Said prints contribute to most of the size of the logfile,
which can easily become large over time.
By introducing this flag, the size of the logfile in the basic branin
example is reduced from approx. 300K to 16K.