### PR TITLE
Removed lambda functions from param_space due to pickle issue.

### DIFF
--- a/hypermapper/space.py
+++ b/hypermapper/space.py
@@ -778,10 +778,6 @@ class Space:
         self.pdf = None
         self.bw_param = config["bandwidth_parameter"]
         self.bw_n_factor = config["bandwidth_n_factor"]
-        # If we use weights, we have to adapt this to use "neff"
-        self.bw_selector = lambda kde: np.power(
-            kde.n * self.bw_n_factor, -1.0 / (kde.d + self.bw_param)
-        )
 
         hypermapper_mode = config["hypermapper_mode"]["mode"]
         if hypermapper_mode == "exhaustive":


### PR DESCRIPTION
Lambda functions were causing an issue in some setups due to the parallel local search multiprocessing library. The multiprocessing library requires pickling objects, but lambda functions could not be pickled. This fix transforms the lambda functions into regular methods.