### PR TITLE
Fix numpy deprecated dtypes. int->int64, float->float64

### DIFF
--- a/hypermapper/compute_pareto.py
+++ b/hypermapper/compute_pareto.py
@@ -69,7 +69,7 @@ def sequential_is_pareto_efficient_dumb(costs):
     """
     isString = isinstance(costs[0][0], str)
     if isString:
-        costs = costs.astype(np.float)
+        costs = costs.astype(np.float64)
     is_efficient = np.ones(costs.shape[0], dtype=bool)
     for i, c in enumerate(costs):
         is_efficient[i] = np.all(np.any(costs >= c, axis=1))
@@ -95,7 +95,7 @@ def sequential_is_pareto_efficient(costs):
 
     isString = isinstance(costs[0][0], str)
     if isString:
-        costs = costs.astype(np.float)
+        costs = costs.astype(np.float64)
     is_efficient = np.ones(costs.shape[0], dtype=bool)
     for i, c in enumerate(costs):
         if is_efficient[i]:

--- a/hypermapper/space.py
+++ b/hypermapper/space.py
@@ -1811,7 +1811,7 @@ class Space:
         if len(arr) == 0:
             absolute_configuration_index = 0
         else:
-            absolute_configuration_index = np.asarray(arr, dtype=np.int).max() + 1
+            absolute_configuration_index = np.asarray(arr, dtype=np.int64).max() + 1
 
         # See if input space is big enough otherwise it doesn't make sense to draw number_of_RS samples.
         if (self.get_space_size() - len(fast_addressing_of_data_array)) <= number_of_RS:
@@ -2209,7 +2209,7 @@ class Space:
         if len(arr) == 0:
             absolute_configuration_index = 0
         else:
-            absolute_configuration_index = np.asarray(arr, dtype=np.int).max() + 1
+            absolute_configuration_index = np.asarray(arr, dtype=np.int64).max() + 1
 
         # See if input space is big enough otherwise it doesn't make sense to draw number_of_samples samples.
         if (


### PR DESCRIPTION
Hi 
hypermapper does not work out of the box with numpy version 1.24.2, mainly due to some dtype deprecations in 1.20.0 (https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations).
The fixes in this PR should get it working again. The new dtypes are as per the recommendations in the numpy release note.