### PR TITLE
Fixes for Batch Optimization for HyperMapper-v3

### DIFF
--- a/hypermapper/bo/bo.py
+++ b/hypermapper/bo/bo.py
@@ -10,6 +10,7 @@ from hypermapper.param import space
 from hypermapper.param.data import DataArray
 from hypermapper.param.doe import get_doe_sample_configurations
 from hypermapper.param.sampling import random_sample
+from hypermapper.param.transformations import preprocess_parameters_array
 from hypermapper.util.file import load_previous
 from hypermapper.util.file import (
     initialize_output_data_file,
@@ -247,10 +248,11 @@ def main(settings, black_box_function=None):
                         (best_configurations, best_configuration.unsqueeze(0)), 0
                     )
                     if batch_idx < settings["batch_size"] - 1:
+                        preprocessed_best_configuration = preprocess_parameters_array(best_configuration.unsqueeze(0), param_space)
                         fantasized_values = torch.tensor(
                             [
                                 model.get_mean_and_std(
-                                    best_configuration.unsqueeze(0), False
+                                    preprocessed_best_configuration[0].unsqueeze(0), False
                                 )[0]
                                 for model in regression_models
                             ]
@@ -279,7 +281,6 @@ def main(settings, black_box_function=None):
                 allow_repetitions=False,
                 previously_run=data_array.string_dict,
             )
-
         ##################
         # Evaluate configs
         ##################

--- a/hypermapper/param/space.py
+++ b/hypermapper/param/space.py
@@ -668,20 +668,40 @@ class Space:
         original_configurations = self.convert(configurations, "internal", "original")
         objective_values = []
         timestamps = []
-        for original_configuration in original_configurations:
-            output = black_box_function(
-                {
-                    name: value
-                    for name, value in zip(self.parameter_names, original_configuration)
-                }
-            )
-            if isinstance(output, tuple):
-                output = list(output)
-            if not (type(output) is list or type(output) is dict):
-                output = [output]
-            objective_values.append(output)
-            timestamps.append(self.current_milli_time() - beginning_of_time)
-
+        configurations_run = 0
+        while configurations_run < len(original_configurations):
+            if len(original_configurations) > 1:
+                outputs = black_box_function(
+                    [
+                        {
+                            name: value 
+                            for name,value in zip(self.parameter_names, config)
+                        }
+                        for config in original_configurations[configurations_run:configurations_run+self.settings["batch_size"]]
+                    ]
+                )
+                for output in outputs:
+                    if isinstance(output, tuple):
+                        output = list(output)
+                    if not (type(output) is list or type(output) is dict):
+                        output = [output]
+                    objective_values.append(output)
+                    timestamps.append(self.current_milli_time() - beginning_of_time)
+            else:
+                output = black_box_function(
+                    {
+                        name: value
+                        for name, value in zip(self.parameter_names, original_configurations[configurations_run:configurations_run+self.settings["batch_size"]])
+                    }
+                )
+                if isinstance(output, tuple):
+                    output = list(output)
+                if not (type(output) is list or type(output) is dict):
+                    output = [output]
+                objective_values.append(output)
+                timestamps.append(self.current_milli_time() - beginning_of_time)
+            configurations_run += self.settings["batch_size"]
+        
         output_names = (
             self.metric_names
             + ([self.feasible_output_name] if self.enable_feasible_predictor else [])


### PR DESCRIPTION
Batch Optimization did not work as intended on HyperMapper-V3
- The `run_configurations_with_black_box` sends configurations to the black box function sequentially.
- `best_configuration` is sent to the `get_mean_and_std` function without any preprocessing, and ends up throwing an error when performing batch optimization.  

Note: This fix does need some additional work. PyTorch throws warnings about non-standardized data, but I was unfortunately not able to figure our the source for the warnings.